### PR TITLE
Improved reliability

### DIFF
--- a/DeleteVisuallyRedundant.py
+++ b/DeleteVisuallyRedundant.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import getopt
 import os
 import re
@@ -26,45 +28,52 @@ os.system("findimagedupes -R \"{}\" > \"{}\"".format(filepath, dupsFile))
 def deleteAllButLargestAndOldest(filepaths):
 	maxSize = 0
 	maxFilepaths = []
+	remainingFilepaths = []
 
 	for filepath in filepaths:
 		size = os.stat(filepath).st_size
 		if (size > maxSize):
 			maxSize = size
-		
+
 	for filepath in filepaths:
 		size = os.stat(filepath).st_size
-		
+
 		if(size < maxSize):
 			print("D:", filepath)
 			if toDryRun == False:
 				os.remove(filepath)
-		
-		if (size == maxSize):
+		elif (size == maxSize):
 			maxFilepaths.append(filepath)
-			
+
 	if (len(maxFilepaths) > 1):
-		oldestModifiedTime = 0
-		
+		oldestModifiedTime = float("inf")
+
 		for maxFilepath in maxFilepaths:
-			modifiedTime = os.stat(filepath).st_mtime
-			
+			modifiedTime = os.stat(maxFilepath).st_mtime
+
 			if (modifiedTime < oldestModifiedTime):
 				oldestModifiedTime = modifiedTime
-		
+
 		for maxFilepath in maxFilepaths:
-			modifiedTime = os.stat(filepath).st_mtime
-			
+			modifiedTime = os.stat(maxFilepath).st_mtime
+
 			if(modifiedTime > oldestModifiedTime):
 				print("D:", maxFilepath)
 				if toDryRun == False:
 					os.remove(maxFilepath)
+			elif (modifiedTime == oldestModifiedTime):
+				remainingFilepaths.append(maxFilepath)
 
+	# Remove all but one duplicate if any still exist
+	for remainingFilepath in remainingFilepaths[1:]:
+		if toDryRun == False:
+			os.remove(remainingFilepath)
 
+filename_regex = re.compile("(.+?\.(?:jpe?g|png|gif))(?:\s+|$)", flags=re.IGNORECASE)
 with open(dupsFile, 'r') as fp:
 	for cnt, line in enumerate(fp):
-		matches = re.findall("(?:(.*?(?:jpg|png|gif))[\s]{0,1})+?", line)
-		
+		matches = filename_regex.findall(line)
+
 		deleteAllButLargestAndOldest(matches)
 
 if toRemoveDupFile:


### PR DESCRIPTION
The following changes were made:

1. Add shebang, so the script can be run with ./DeleteVisuallyRedundant.py
2. Start oldest modified time at inf, i.e. the newest file. 0 will always be the oldest file, but that one doesn't exist
3. Change `maxFilepath` to `filepath` when checking the age of the file
4. Delete any duplicates of same size with same modified time
5. Improve the regex on files containing spaces, different cases, or that contain the extension string somewhere in the path
6. Precompile regex ~~to speed things up~~

Explanation for each change:

1. The file is marked as executable, however, it isn't executable in its current state. It needs to be launched by Python. Attempting to run it with ./DeleteVisuallyRedundant.py will attempt to run it as a shell script. The shebang makes it run as a Python3 script.
2. When the initial oldestModifiedTime is set to 0, any file that is checked will have a greater modified time (because no modified time can be below 0, AFAIK). The code checks `if (modifiedTime < oldestModifiedTime):`, but this statement always returns false. This ultimately means that all files are considered "newer" so they are deleted. This issue only presents itself if two or more files are the same size. I think this is the issue seen in #4. The fix is to start at float("inf") as the first modified time we check will be less than this.
3. When checking the modified time, the code is looking at `filepath`, however, it is iterating with a variable called `maxFilepath`. I have changed the name to always be `filepath`.
4. Do one last pass at the end to remove any remaining duplicates. This can happen if a file has the same size and modified time as another file (typically when a file is copied). Just delete all but one of the remaining files.
5. Improve the regex. You can compare the differences here: [old](https://regex101.com/r/Z7oBDy/1) vs. [new](https://regex101.com/r/dBNu08/1)
6. ~~Use `re.compile` to compile the regex first so it doesn't need to be compiled in the loop each time. This should reduce the runtime of the script~~ [This is not true](https://stackoverflow.com/a/452143)